### PR TITLE
Column alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ optional arguments:
 To run the tests, enter:
 
 ```commandline
-nosetest
+nosetests
 ```
 
 ## Issue tracker

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ with open('LICENSE') as f:
 
 setup(
     name='csv2md',
-    version='1.0.0',
+    version='1.0.1',
     description='Command line tool for converting CSV files into Markdown tables.',
     long_description=readme,
+    long_description_content_type='text/markdown',
     author='Lev Zakharov',
     author_email='l.j.zakharov@gmail.com',
     url='https://github.com/lzakharov/csv2md',
@@ -19,7 +20,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     entry_points={
         'console_scripts': [
-            'csv2md = csv2md.__main__:main'
+            'csv2md = csv2md:main'
         ]
     }
 )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -43,6 +43,14 @@ normal_md = (
     '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air, moon roof, loaded | 4799.00 |'
 )
 
+normal_md_w_alignment = (
+    '| year | make  | model                      | description                       | price   |\n'
+    '| :--: | :---: | -------------------------: | --------------------------------- | ------: |\n'
+    '| 1997 | Ford  | E350                       | ac, abs, moon                     | 3000.00 |\n'
+    '| 1999 | Chevy | Venture «Extended Edition» |                                   | 4900.00 |\n'
+    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air, moon roof, loaded | 4799.00 |'
+)
+
 
 class BasicTestSuit(unittest.TestCase):
     """Basic test cases."""
@@ -81,6 +89,12 @@ class BasicTestSuit(unittest.TestCase):
     def test_parsing_from_one_normal_csv_file(self, mock_stdout):
         csv2md.main()
         self.assertEqual(mock_stdout.getvalue().strip(), normal_md)
+
+    @patch('sys.argv', ['csv2md', '--center-fields', '1,2', '--right-fields', '3,5', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', 'normal.csv')])
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_parsing_from_one_normal_csv_file_with_alignment(self, mock_stdout):
+        csv2md.main()
+        self.assertEqual(mock_stdout.getvalue().strip(), normal_md_w_alignment)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added some options to let columns be center or right aligned:

```
usage: csv2md [-h] [-d DELIMITER] [-q QUOTECHAR]
              [--center-fields center_FIELDS] [--right-fields RIGHT_FIELDS]
              [CSV_FILE [CSV_FILE ...]]

Parse CSV files into Markdown tables.

usage: csv2md [-h] [-d DELIMITER] [-q QUOTECHAR]
              [--center-fields CENTER_FIELDS] [--right-fields RIGHT_FIELDS]
              [CSV_FILE [CSV_FILE ...]]

Parse CSV files into Markdown tables.

positional arguments:
  CSV_FILE              One or more CSV files to parse

optional arguments:
  -h, --help            show this help message and exit
  -d DELIMITER, --delimiter DELIMITER
                        delimiter character. Default is ','
  -q QUOTECHAR, --quotechar QUOTECHAR
                        quotation character. Default is '"'
  --center-fields CENTER_FIELDS
                        fields to center aligned
  --right-fields RIGHT_FIELDS
                        fields to right aligned
```