### PR TITLE
Update README.md: Add "TSV Files" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ options:
   -H, --no-header-row   specify that the input CSV file has no header row. Will create default headers in Excel format (a,b,c,...)
 ```
 
+## TSV Files
+
+To convert TSV (Tab-separated values) files, you can specify a tab character as delimiter using the following command:
+
+```commandline
+csv2md -d $'\t' [TSV_FILE ...]
+```
+
 ## Running Tests
 
 To run the tests, enter:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Generate Markdown table from CSV file:
 csv2md table.csv
 ```
 
+Generate Markdown table from TSV file:
+
+```commandline
+csv2md -d $'\t' table.tsv
+```
+
 Generate Markdown tables from list of CSV files:
 
 ```commandline
@@ -105,14 +111,6 @@ options:
   -r [RIGHT_ALIGNED_COLUMNS ...], --right-aligned-columns [RIGHT_ALIGNED_COLUMNS ...]
                         column numbers with right alignment (from zero)
   -H, --no-header-row   specify that the input CSV file has no header row. Will create default headers in Excel format (a,b,c,...)
-```
-
-## TSV Files
-
-To convert TSV (Tab-separated values) files, you can specify a tab character as delimiter using the following command:
-
-```commandline
-csv2md -d $'\t' [TSV_FILE ...]
 ```
 
 ## Running Tests


### PR DESCRIPTION
If this pull request is merged, it will add a section to the README explaining briefly how to specify the tab character on the command line. Whilst technically this is not about `csv2md` itself, I think the shell syntax required is non-obvious, so users will benefit from the information. [TSV](https://en.wikipedia.org/wiki/Tab-separated_values) is a fairly common file format.