### PR TITLE
fix: `DeprecationWarning`: invalid escape sequence in tests

### DIFF
--- a/csv2md/test_table.py
+++ b/csv2md/test_table.py
@@ -40,7 +40,7 @@ normal_md = (
     '| ---- | ----- | -------------------------- | ------------------------------------- | ------- |\n'
     '| 1997 | Ford  | E350                       | ac, abs, moon                         | 3000.00 |\n'
     '| 1999 | Chevy | Venture «Extended Edition» |                                       | 4900.00 |\n'
-    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'
+    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \\| moon roof \\| loaded | 4799.00 |'
 )
 
 normal_md_with_alignment = (
@@ -48,7 +48,7 @@ normal_md_with_alignment = (
     '| ---- | :---: | :------------------------: | ------------------------------------- | ------: |\n'
     '| 1997 | Ford  | E350                       | ac, abs, moon                         | 3000.00 |\n'
     '| 1999 | Chevy | Venture «Extended Edition» |                                       | 4900.00 |\n'
-    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'
+    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \\| moon roof \\| loaded | 4799.00 |'
 )
 
 normal_md_with_default_columns = (
@@ -57,7 +57,7 @@ normal_md_with_default_columns = (
     '| year | make  | model                      | description                           | price   |\n'
     '| 1997 | Ford  | E350                       | ac, abs, moon                         | 3000.00 |\n'
     '| 1999 | Chevy | Venture «Extended Edition» |                                       | 4900.00 |\n'
-    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'
+    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \\| moon roof \\| loaded | 4799.00 |'
 )
 
 


### PR DESCRIPTION
```
==================================================================== warnings summary ====================================================================
csv2md/test_table.py:43
  /mnt/DATA/code/csv2md/csv2md/test_table.py:43: DeprecationWarning: invalid escape sequence \|
    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'

csv2md/test_table.py:51
  /mnt/DATA/code/csv2md/csv2md/test_table.py:51: DeprecationWarning: invalid escape sequence \|
    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'

csv2md/test_table.py:60
  /mnt/DATA/code/csv2md/csv2md/test_table.py:60: DeprecationWarning: invalid escape sequence \|
    '| 1996 | Jeep  | Grand Cherokee             | MUST SELL! air \| moon roof \| loaded | 4799.00 |'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 10 passed, 3 warnings in 0.06s =============================================================
```